### PR TITLE
Restored GlassDoor Functionality

### DIFF
--- a/jobpy/config/settings.py
+++ b/jobpy/config/settings.py
@@ -5,7 +5,7 @@ default_args = {
     # paths:
     'MASTERLIST_PATH' : os.path.join('data', 'jobs_masterlist.csv'),
     'FILTERLIST_PATH' : os.path.join('data', 'filterlist.json'),
-    'BLACKLIST_PATH'  : os.path.join('config', 'blacklist.json'),
+    'BLACKLIST_PATH'  : os.path.join('jobpy/config', 'blacklist.json'),
     "SEARCHTERMS_PATH"  : os.path.join('jobpy/config','search_terms.json'),
     # logging config:
     'LOG_PATH'  : 'jobpy.log',

--- a/jobpy/glassdoor.py
+++ b/jobpy/glassdoor.py
@@ -167,8 +167,11 @@ class GlassDoor(JobPy):
             # no blurb is available in glassdoor job soups
             job['blurb'] = ''
 
-            # no date is available in glassdoor job soups
-            job['date'] = ''
+            try:
+                job['date'] = s.find('div', attrs={'class', 'jobLabels'}).find(
+                    'span', attrs={'class', 'jobLabel nowrap'}).text.strip()
+            except AttributeError:
+                job['date'] = ''
 
             try:
                 job['id'] = s.get('data-id')
@@ -180,7 +183,7 @@ class GlassDoor(JobPy):
                 job['id'] = ''
                 job['link'] = ''
 
-            # traverse the job link to extract the blurb and date
+            # traverse the job link to extract the blurb
             search = job['link']
             logging.info(
                 'getting glassdoor search: {}'.format(search))
@@ -193,12 +196,6 @@ class GlassDoor(JobPy):
                     id='JobDescriptionContainer').text.strip()
             except AttributeError:
                 job['blurb'] = ''
-
-            try:
-                job['date'] = job_link_soup.find(
-                    'span', attrs={'class', 'minor nowrap'}).text.strip()
-            except AttributeError:
-                job['date'] = ''
 
             filter_non_printables(job)
             post_date_from_relative_post_age(job)

--- a/jobpy/monster.py
+++ b/jobpy/monster.py
@@ -104,6 +104,8 @@ class Monster(JobPy):
 
             # traverse the job link to extract the blurb
             search = job['link']
+            logging.info(
+                'getting monster search: {}'.format(search))
             request_HTML = requests.get(search)
             job_link_soup = bs4.BeautifulSoup(
                 request_HTML.text, self.bs4_parser)


### PR DESCRIPTION
I have restored glassdoor functionality.
It never really "broke" it's just that glassdoor updated it's website.
If anything it made scraping easier.
However, glassdoor now searches for bots.  So, sometimes you will be missing a blurb or date.
I've noticed when it fails it's because I see something like this:
![image](https://user-images.githubusercontent.com/15698049/60400641-9c11bb80-9b44-11e9-9ca1-acbaa2658510.png)
But that is something we cannot fix.  We still have the link for the job so it is not required.
fixes #9